### PR TITLE
More keybindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [Unreleased]
+- Add Keybindings to run test commands
 
 ## [1.2.0] - 2019-10-03
 

--- a/README.md
+++ b/README.md
@@ -19,15 +19,21 @@ The default keybinding is `Cmd + Shift + J` (macOS) and `Ctrl + Shift + J` (Linu
 
 ### Elixir Test: Run all tests on file
 
+The default keybinding is `Cmd + Shift + K, F` (macOS) and `Ctrl + Shift + K, F` (Linux/Windows)
+
 ![Run all tests on file](https://media.giphy.com/media/lr81HlKkF60BoMnlvU/giphy.gif)
 
 ### Elixir Test: Run test at cursor
 
 This one does the same as above, but for a single test.
 
+The default keybinding is `Cmd + Shift + K, C` (macOS) and `Ctrl + Shift + K, C` (Linux/Windows)
+
 ### Elixir Test: Run test suite
 
 This one does the same as above, but for the entire test suite.
+
+The default keybinding is `Cmd + Shift + K, S` (macOS) and `Ctrl + Shift + K, S` (Linux/Windows)
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,21 @@
         "command": "extension.elixirJumpToTest",
         "key": "ctrl+shift+j",
         "mac": "cmd+shift+j"
+      },
+      {
+        "command": "extension.elixirRunTestAtCursor",
+        "key": "ctrl+shift+k c",
+        "mac": "cmd+shift+k c"
+      },
+      {
+        "command": "extension.elixirRunTestFile",
+        "key": "ctrl+shift+k f",
+        "mac": "cmd+shift+k f"
+      },
+      {
+        "command": "extension.elixirRunTestSuite",
+        "key": "ctrl+shift+k s",
+        "mac": "cmd+shift+k s"
       }
     ]
   },


### PR DESCRIPTION
Add keybindings for all commands

- `cmd+shit+k s`, to run the whole test suite
- `cmd+shift+k f`, to run the current test file
- `cmd+shift+k c`, to run the test at cursor