### PR TITLE
Add `when` on keybindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,22 +45,26 @@
       {
         "command": "extension.elixirJumpToTest",
         "key": "ctrl+shift+j",
-        "mac": "cmd+shift+j"
+        "mac": "cmd+shift+j",
+        "when": "editorTextFocus && editorLangId == 'elixir'"
       },
       {
         "command": "extension.elixirRunTestAtCursor",
         "key": "ctrl+shift+k c",
-        "mac": "cmd+shift+k c"
+        "mac": "cmd+shift+k c",
+        "when": "editorTextFocus && editorLangId == 'elixir'"
       },
       {
         "command": "extension.elixirRunTestFile",
         "key": "ctrl+shift+k f",
-        "mac": "cmd+shift+k f"
+        "mac": "cmd+shift+k f",
+        "when": "editorTextFocus && editorLangId == 'elixir'"
       },
       {
         "command": "extension.elixirRunTestSuite",
         "key": "ctrl+shift+k s",
-        "mac": "cmd+shift+k s"
+        "mac": "cmd+shift+k s",
+        "when": "editorTextFocus && editorLangId == 'elixir'"
       }
     ]
   },


### PR DESCRIPTION
Fixes #42 

Followed this doc to do that: https://code.visualstudio.com/api/references/contribution-points#keybinding-example

We have this problem reported here: https://github.com/samuelpordeus/vscode-elixir-test/issues/42#issuecomment-540009740 

If I understood it correctly, this `editorLangId == 'elixir'` will only work if you have the `ElixirLS` plugin, and then when you press `CMD+K M` and open the `Select Language Mode` you will have the `elixir` on the list, like this:
![image](https://user-images.githubusercontent.com/7904540/66608716-98eb8a00-eb8d-11e9-8073-c614bfcba1b5.png)

I added it in my personal keybindings and works perfectly :)

Feel free to reject this PR if you want, because merging it we will create this dependency on the ElixirLS plugin, you know? So it also may be a good idea to wait for VSCode to officially support the Elixir language. 🤷‍♂ And then we can also close the issue.