### PR TITLE
Add command to run all tests in folder (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ This one does the same as above, but for a single test.
 
 The default keybinding is `Cmd + Shift + K, C` (macOS) and `Ctrl + Shift + K, C` (Linux/Windows)
 
+### Elixir Test: Run all tests in a folder
+
+This one does the same as above, but for all tests within a folder.
+
+The default keybinding is `Cmd + Shift + K, D` (macOS) and `Ctrl + Shift + K, D` (Linux/Windows)
+
+Alternatively, right-click the folder in the Explorer and select `Elixir Test: Run all tests in a folder`.
+
 ### Elixir Test: Run test suite
 
 This one does the same as above, but for the entire test suite.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "activationEvents": [
     "onCommand:extension.elixirJumpToTest",
     "onCommand:extension.elixirRunTestFile",
+    "onCommand:extension.elixirRunTestFolder",
     "onCommand:extension.elixirRunTestSuite",
     "onCommand:extension.elixirRunTestAtCursor"
   ],
@@ -33,6 +34,10 @@
         "title": "Elixir Test: Run all tests on file"
       },
       {
+        "command": "extension.elixirRunTestFolder",
+        "title": "Elixir Test: Run all tests in a folder"
+      },
+      {
         "command": "extension.elixirRunTestAtCursor",
         "title": "Elixir Test: Run test at cursor"
       },
@@ -41,6 +46,15 @@
         "title": "Elixir Test: Run test suite"
       }
     ],
+    "menus": {
+      "explorer/context": [
+        {
+          "when": "explorerResourceIsFolder",
+          "command": "extension.elixirRunTestFolder",
+          "group": "elixirTest"
+        }
+      ]
+    },
     "keybindings": [
       {
         "command": "extension.elixirJumpToTest",
@@ -56,6 +70,11 @@
         "command": "extension.elixirRunTestFile",
         "key": "ctrl+shift+k f",
         "mac": "cmd+shift+k f"
+      },
+      {
+        "command": "extension.elixirRunTestFolder",
+        "key": "ctrl+shift+k d",
+        "mac": "cmd+shift+k d"
       },
       {
         "command": "extension.elixirRunTestSuite",

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -1,6 +1,7 @@
 const jumpToTest = require('./jumpToTest');
 const runTestAtCursor = require('./runTestAtCursor');
 const runTestFile = require('./runTestFile');
+const runTestFolder = require('./runTestFolder');
 const runTestSuite = require('./runTestSuite');
 
-module.exports = [jumpToTest, runTestAtCursor, runTestFile, runTestSuite];
+module.exports = [jumpToTest, runTestAtCursor, runTestFile, runTestFolder, runTestSuite];

--- a/src/commands/runTestFolder.js
+++ b/src/commands/runTestFolder.js
@@ -1,0 +1,38 @@
+const vscode = require('vscode');
+const path = require('path');
+
+function handler(folderUri) {
+  let selectedFolder;
+
+  if (folderUri) {
+    selectedFolder = folderUri.fsPath;
+  } else {
+    const activeFile = vscode.window.activeTextEditor;
+    if (!activeFile) {
+      return;
+    }
+
+    selectedFolder = path.dirname(activeFile.document.fileName);
+  }
+
+  selectedFolder += selectedFolder.endsWith('/') ? '' : '/';
+
+  const isTestFolder = selectedFolder.includes('/test/');
+  const isUmbrella = selectedFolder.includes('/apps/');
+
+  if (isTestFolder === true) {
+    const testPathFilter = isUmbrella ? /.*\/(apps\/.*)$/ : /.*\/(test\/.*)$/;
+    const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
+    terminal.sendText(`mix test ${selectedFolder.match(testPathFilter)[1]}`);
+    terminal.show();
+  } else {
+    vscode.window.showInformationMessage(
+      'This folder is not a test folder.',
+    );
+  }
+}
+
+module.exports = {
+  name: 'extension.elixirRunTestFolder',
+  handler,
+};


### PR DESCRIPTION
Closes #43 

I was unsure about the keybinding to go with so I went for CTRL/CMD + Shift + K D (as in Directory :smile: ).

 - Implemented command handler
    - Based off `runTestFile.js`. When called from the context menu (right click folder), a folder URI is passed so we consider that as the path. 
    - We make sure the path ends with `/` so that filtering the test path is simpler.

 - Added action to explorer's context menu

 - Updated README.md

Feedback is always appreciated! :rocket: 