### PR TITLE
Fixed typo in runTestAtCursor

### DIFF
--- a/src/commands/runTestAtCursor.js
+++ b/src/commands/runTestAtCursor.js
@@ -20,7 +20,7 @@ function handler() {
     const testPathFilter = isUmbrella ? /.*\/(apps\/.*)$/ : /.*\/(test\/.*)$/;
     const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
     terminal.sendText(
-      `mix test ${openedFilename.match(testPathFilter)[1]}:${cursorLine}`,
+      `mix test ${openedFilename.match(testPathFilter)[1]}: ${cursorLine}`,
     );
     terminal.show();
   } else {


### PR DESCRIPTION
This fixes a typo that allows runTestAtCursor to work