### PR TITLE
Add commands to use Watcher library

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ This one does the same as above, but for the entire test suite.
 
 The default keybinding is `Cmd + Shift + K, S` (macOS) and `Ctrl + Shift + K, S` (Linux/Windows)
 
+### Watch tests
+
+To watch tests, you need to install [mix_test_watch](https://hex.pm/packages/mix_test_watch) dependency.
+
 ## Contributing
 
 Feel free to suggest some new features or report bugs [creating a new issue](https://github.com/samuelpordeus/vscode-elixir-test/issues/new).

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "displayName": "Elixir Test",
   "description": "An extension with a few commands that helps you with your Elixir tests",
   "icon": "icon.png",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "engines": {
     "vscode": "^1.38.0"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "onCommand:extension.elixirRunTestFolder",
     "onCommand:extension.elixirRunTestSuite",
     "onCommand:extension.elixirRunTestAtCursor",
-    "onCommand:extension.elixirWatchTestFile"
+    "onCommand:extension.elixirWatchTestFile",
+    "onCommand:extension.elixirWatchTestFolder",
+    "onCommand:extension.elixirWatchTestAtCursor",
+    "onCommand:extension.elixirWatchTestSuite"
   ],
   "main": "./src/extension.js",
   "contributes": {
@@ -49,6 +52,18 @@
       {
         "command": "extension.elixirWatchTestFile",
         "title": "Elixir Test: Watch all tests on file"
+      },
+      {
+        "command": "extension.elixirWatchTestFolder",
+        "title": "Elixir Test: Watch all tests in a folder"
+      },
+      {
+        "command": "extension.elixirWatchTestAtCursor",
+        "title": "Elixir Test: Watch test at cursor"
+      },
+      {
+        "command": "extension.elixirWatchTestSuite",
+        "title": "Elixir Test: Watch test suite"
       }
     ],
     "menus": {
@@ -88,12 +103,6 @@
         "command": "extension.elixirRunTestSuite",
         "key": "ctrl+shift+k s",
         "mac": "cmd+shift+k s",
-        "when": "editorTextFocus && editorLangId == 'elixir'"
-      },
-      {
-        "command": "extension.elixirWatchTestFile",
-        "key": "ctrl+shift+k w",
-        "mac": "cmd+shift+k w",
         "when": "editorTextFocus && editorLangId == 'elixir'"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "onCommand:extension.elixirRunTestFile",
     "onCommand:extension.elixirRunTestFolder",
     "onCommand:extension.elixirRunTestSuite",
-    "onCommand:extension.elixirRunTestAtCursor"
+    "onCommand:extension.elixirRunTestAtCursor",
+    "onCommand:extension.elixirWatchTestFile"
   ],
   "main": "./src/extension.js",
   "contributes": {
@@ -44,6 +45,10 @@
       {
         "command": "extension.elixirRunTestSuite",
         "title": "Elixir Test: Run test suite"
+      },
+      {
+        "command": "extension.elixirWatchTestFile",
+        "title": "Elixir Test: Watch all tests on file"
       }
     ],
     "menus": {
@@ -83,6 +88,12 @@
         "command": "extension.elixirRunTestSuite",
         "key": "ctrl+shift+k s",
         "mac": "cmd+shift+k s",
+        "when": "editorTextFocus && editorLangId == 'elixir'"
+      },
+      {
+        "command": "extension.elixirWatchTestFile",
+        "key": "ctrl+shift+k w",
+        "mac": "cmd+shift+k w",
         "when": "editorTextFocus && editorLangId == 'elixir'"
       }
     ],

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -4,6 +4,9 @@ const runTestFile = require('./runTestFile');
 const runTestFolder = require('./runTestFolder');
 const runTestSuite = require('./runTestSuite');
 const watchTestFile = require('./watchTestFile');
+const watchTestFolder = require('./watchTestFolder');
+const watchTestAtCursor = require('./watchTestAtCursor');
+const watchTestSuite = require('./watchTestSuite');
 
 module.exports = [
   jumpToTest,
@@ -11,5 +14,8 @@ module.exports = [
   runTestFile,
   runTestFolder,
   runTestSuite,
-  watchTestFile
+  watchTestFile,
+  watchTestFolder,
+  watchTestAtCursor,
+  watchTestSuite,
 ];

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -3,5 +3,13 @@ const runTestAtCursor = require('./runTestAtCursor');
 const runTestFile = require('./runTestFile');
 const runTestFolder = require('./runTestFolder');
 const runTestSuite = require('./runTestSuite');
+const watchTestFile = require('./watchTestFile');
 
-module.exports = [jumpToTest, runTestAtCursor, runTestFile, runTestFolder, runTestSuite];
+module.exports = [
+  jumpToTest,
+  runTestAtCursor,
+  runTestFile,
+  runTestFolder,
+  runTestSuite,
+  watchTestFile
+];

--- a/src/commands/jumpToTest.js
+++ b/src/commands/jumpToTest.js
@@ -66,25 +66,27 @@ function handler() {
     return;
   }
 
-  const startDir = openedFile[1]
-  const testOrLib = openedFile[2]
-  const postDir = openedFile[3]
-  const fileName = openedFile[4]
-  const replacedLibOrTest = testOrLib === 'lib' ? 'test': 'lib';
+  const startDir = openedFile[1];
+  const testOrLib = openedFile[2];
+  const postDir = openedFile[3];
+  const fileName = openedFile[4];
+  const replacedLibOrTest = testOrLib === 'lib' ? 'test' : 'lib';
+  let newFilename = '';
 
   if (fileName.includes('_test')) {
     const strippedFileName = fileName.replace('_test', '');
     newFilename = `${strippedFileName}.ex`;
-  }
-  else{
-    newFilename = `${fileName}_test.exs`
+  } else {
+    newFilename = `${fileName}_test.exs`;
   }
 
-  const fileToOpen = vscode.workspace.asRelativePath(startDir+replacedLibOrTest+postDir+newFilename)
+  const fileToOpen = vscode.workspace.asRelativePath(
+    startDir + replacedLibOrTest + postDir + newFilename,
+  );
 
   vscode.workspace.findFiles(fileToOpen, '**/.elixir_ls/**').then((files) => {
     if (!files.length) {
-      askToCreateANewFile(startDir+replacedLibOrTest+postDir, newFilename);
+      askToCreateANewFile(startDir + replacedLibOrTest + postDir, newFilename);
     } else {
       const file = files[0].fsPath;
       openFile(file);

--- a/src/commands/jumpToTest.js
+++ b/src/commands/jumpToTest.js
@@ -1,4 +1,5 @@
 const vscode = require('vscode');
+const validations = require('../helpers/validations');
 
 function openFile(file) {
   return vscode.workspace
@@ -59,8 +60,7 @@ function handler() {
   }
 
   const openedFilename = activeFile.document.fileName;
-  const isCodeFile = /(.*\/)(test|lib)(.*\/)(.*)(\.\w+)$/;
-  const openedFile = openedFilename.match(isCodeFile);
+  const openedFile = validations.isCodeFile(openedFilename);
 
   if (!openedFile) {
     return;

--- a/src/commands/runTestAtCursor.js
+++ b/src/commands/runTestAtCursor.js
@@ -14,9 +14,9 @@ function handler() {
   */
   const cursorLine = activeFile.selection.active.line + 1;
 
-  const isWindows = validations.isWindows(selectedFolder);
-  const isTestFolder = validations.isTestFolder(selectedFolder);
-  const isUmbrella = validations.isUmbrella(selectedFolder);
+  const isWindows = validations.isWindows(openedFilename);
+  const isTestFile = validations.isTestFile(openedFilename);
+  const isUmbrella = validations.isUmbrella(openedFilename);
 
   const config = vscode.workspace.getConfiguration('vscode-elixir-test');
 

--- a/src/commands/runTestAtCursor.js
+++ b/src/commands/runTestAtCursor.js
@@ -1,4 +1,5 @@
 const vscode = require('vscode');
+const validations = require('../helpers/validations');
 
 function handler() {
   const activeFile = vscode.window.activeTextEditor;
@@ -13,13 +14,14 @@ function handler() {
   */
   const cursorLine = activeFile.selection.active.line + 1;
 
-  const isTestFile = openedFilename.includes('_test.exs');
-  const isUmbrella = openedFilename.includes('/apps/');
+  const isWindows = validations.isWindows(selectedFolder);
+  const isTestFolder = validations.isTestFolder(selectedFolder);
+  const isUmbrella = validations.isUmbrella(selectedFolder);
 
   const config = vscode.workspace.getConfiguration('vscode-elixir-test');
 
   if (isTestFile === true) {
-    const testPathFilter = isUmbrella ? /.*\/(apps\/.*)$/ : /.*\/(test\/.*)$/;
+    const testPathFilter = validations.getTestPathFilter(isUmbrella, isWindows);
     const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
     terminal.sendText(
       `mix test ${openedFilename.match(testPathFilter)[1]}:${cursorLine}`,

--- a/src/commands/runTestFile.js
+++ b/src/commands/runTestFile.js
@@ -16,7 +16,7 @@ function handler() {
   const config = vscode.workspace.getConfiguration('vscode-elixir-test');
 
   if (isTestFile === true) {
-    let testPathFilter = validations.getTestPathFilter(isUmbrella, isWindows);
+    const testPathFilter = validations.getTestPathFilter(isUmbrella, isWindows);
     const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
     terminal.sendText(`mix test ${openedFilename.match(testPathFilter)[1]}`);
     if (config.focusOnTerminalAfterTest) terminal.show();

--- a/src/commands/runTestFile.js
+++ b/src/commands/runTestFile.js
@@ -1,4 +1,5 @@
 const vscode = require('vscode');
+const validations = require('../helpers/validations');
 
 function handler() {
   const activeFile = vscode.window.activeTextEditor;
@@ -8,13 +9,14 @@ function handler() {
 
   const openedFilename = activeFile.document.fileName;
 
-  const isTestFile = openedFilename.includes('_test.exs');
-  const isUmbrella = openedFilename.includes('/apps/');
+  const isWindows = validations.isWindows(openedFilename);
+  const isTestFile = validations.isTestFile(openedFilename);
+  const isUmbrella = validations.isUmbrella(openedFilename);
 
   const config = vscode.workspace.getConfiguration('vscode-elixir-test');
 
   if (isTestFile === true) {
-    const testPathFilter = isUmbrella ? /.*\/(apps\/.*)$/ : /.*\/(test\/.*)$/;
+    let testPathFilter = validations.getTestPathFilter(isUmbrella, isWindows);
     const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
     terminal.sendText(`mix test ${openedFilename.match(testPathFilter)[1]}`);
     if (config.focusOnTerminalAfterTest) terminal.show();

--- a/src/commands/runTestFolder.js
+++ b/src/commands/runTestFolder.js
@@ -1,5 +1,6 @@
 const vscode = require('vscode');
 const path = require('path');
+const validations = require('../helpers/validations');
 
 function handler(folderUri) {
   let selectedFolder;
@@ -17,13 +18,14 @@ function handler(folderUri) {
 
   selectedFolder += selectedFolder.endsWith('/') ? '' : '/';
 
-  const isTestFolder = selectedFolder.includes('/test/');
-  const isUmbrella = selectedFolder.includes('/apps/');
+  const isWindows = validations.isWindows(selectedFolder);
+  const isTestFolder = validations.isTestFolder(selectedFolder);
+  const isUmbrella = validations.isUmbrella(selectedFolder);
 
   const config = vscode.workspace.getConfiguration('vscode-elixir-test');
 
   if (isTestFolder === true) {
-    const testPathFilter = isUmbrella ? /.*\/(apps\/.*)$/ : /.*\/(test\/.*)$/;
+    const testPathFilter = validations.getTestPathFilter(isUmbrella, isWindows);
     const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
     terminal.sendText(`mix test ${selectedFolder.match(testPathFilter)[1]}`);
     if (config.focusOnTerminalAfterTest) terminal.show();

--- a/src/commands/watchTestAtCursor.js
+++ b/src/commands/watchTestAtCursor.js
@@ -1,0 +1,40 @@
+const vscode = require('vscode');
+const validations = require('../helpers/validations');
+
+function handler() {
+  const activeFile = vscode.window.activeTextEditor;
+  if (!activeFile) {
+    return;
+  }
+
+  const openedFilename = activeFile.document.fileName;
+  /*
+  We do a +1 here because the `line` returned is zero based.
+  Ref: https://code.visualstudio.com/api/references/vscode-api#Position
+  */
+  const cursorLine = activeFile.selection.active.line + 1;
+
+  const isWindows = validations.isWindows(openedFilename);
+  const isTestFile = validations.isTestFile(openedFilename);
+  const isUmbrella = validations.isUmbrella(openedFilename);
+
+  const config = vscode.workspace.getConfiguration('vscode-elixir-test');
+
+  if (isTestFile === true) {
+    const testPathFilter = validations.getTestPathFilter(isUmbrella, isWindows);
+    const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
+    terminal.sendText(
+      `mix test.watch ${openedFilename.match(testPathFilter)[1]}:${cursorLine}`,
+    );
+    if (config.focusOnTerminalAfterTest) terminal.show();
+  } else {
+    vscode.window.showInformationMessage(
+      'The current file is not a test file.',
+    );
+  }
+}
+
+module.exports = {
+  name: 'extension.elixirWatchTestAtCursor',
+  handler,
+};

--- a/src/commands/watchTestFile.js
+++ b/src/commands/watchTestFile.js
@@ -16,7 +16,7 @@ function handler() {
   const config = vscode.workspace.getConfiguration('vscode-elixir-test');
 
   if (isTestFile === true) {
-    let testPathFilter = validations.getTestPathFilter(isUmbrella, isWindows);
+    const testPathFilter = validations.getTestPathFilter(isUmbrella, isWindows);
     const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
     terminal.sendText(`mix test.watch ${openedFilename.match(testPathFilter)[1]}`);
     if (config.focusOnTerminalAfterTest) terminal.show();

--- a/src/commands/watchTestFile.js
+++ b/src/commands/watchTestFile.js
@@ -1,4 +1,5 @@
 const vscode = require('vscode');
+const validations = require('../helpers/validations');
 
 function handler() {
   const activeFile = vscode.window.activeTextEditor;
@@ -8,13 +9,14 @@ function handler() {
 
   const openedFilename = activeFile.document.fileName;
 
-  const isTestFile = openedFilename.includes('_test.exs');
-  const isUmbrella = openedFilename.includes('/apps/');
+  const isWindows = validations.isWindows(openedFilename);
+  const isTestFile = validations.isTestFile(openedFilename);
+  const isUmbrella = validations.isUmbrella(openedFilename);
 
   const config = vscode.workspace.getConfiguration('vscode-elixir-test');
 
   if (isTestFile === true) {
-    const testPathFilter = isUmbrella ? /.*\/(apps\/.*)$/ : /.*\/(test\/.*)$/;
+    let testPathFilter = validations.getTestPathFilter(isUmbrella, isWindows);
     const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
     terminal.sendText(`mix test.watch ${openedFilename.match(testPathFilter)[1]}`);
     if (config.focusOnTerminalAfterTest) terminal.show();

--- a/src/commands/watchTestFile.js
+++ b/src/commands/watchTestFile.js
@@ -1,0 +1,31 @@
+const vscode = require('vscode');
+
+function handler() {
+  const activeFile = vscode.window.activeTextEditor;
+  if (!activeFile) {
+    return;
+  }
+
+  const openedFilename = activeFile.document.fileName;
+
+  const isTestFile = openedFilename.includes('_test.exs');
+  const isUmbrella = openedFilename.includes('/apps/');
+
+  const config = vscode.workspace.getConfiguration('vscode-elixir-test');
+
+  if (isTestFile === true) {
+    const testPathFilter = isUmbrella ? /.*\/(apps\/.*)$/ : /.*\/(test\/.*)$/;
+    const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
+    terminal.sendText(`mix test.watch ${openedFilename.match(testPathFilter)[1]}`);
+    if (config.focusOnTerminalAfterTest) terminal.show();
+  } else {
+    vscode.window.showInformationMessage(
+      'The current file is not a test file.',
+    );
+  }
+}
+
+module.exports = {
+  name: 'extension.elixirWatchTestFile',
+  handler,
+};

--- a/src/commands/watchTestFolder.js
+++ b/src/commands/watchTestFolder.js
@@ -1,0 +1,42 @@
+const vscode = require('vscode');
+const path = require('path');
+const validations = require('../helpers/validations');
+
+function handler(folderUri) {
+  let selectedFolder;
+
+  if (folderUri) {
+    selectedFolder = folderUri.fsPath;
+  } else {
+    const activeFile = vscode.window.activeTextEditor;
+    if (!activeFile) {
+      return;
+    }
+
+    selectedFolder = path.dirname(activeFile.document.fileName);
+  }
+
+  selectedFolder += selectedFolder.endsWith('/') ? '' : '/';
+
+  const isWindows = validations.isWindows(selectedFolder);
+  const isTestFolder = validations.isTestFolder(selectedFolder);
+  const isUmbrella = validations.isUmbrella(selectedFolder);
+
+  const config = vscode.workspace.getConfiguration('vscode-elixir-test');
+
+  if (isTestFolder === true) {
+    const testPathFilter = validations.getTestPathFilter(isUmbrella, isWindows);
+    const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
+    terminal.sendText(`mix test.watch ${selectedFolder.match(testPathFilter)[1]}`);
+    if (config.focusOnTerminalAfterTest) terminal.show();
+  } else {
+    vscode.window.showInformationMessage(
+      'This folder is not a test folder.',
+    );
+  }
+}
+
+module.exports = {
+  name: 'extension.elixirWatchTestFolder',
+  handler,
+};

--- a/src/commands/watchTestSuite.js
+++ b/src/commands/watchTestSuite.js
@@ -1,0 +1,14 @@
+const vscode = require('vscode');
+
+const config = vscode.workspace.getConfiguration('vscode-elixir-test');
+
+function handler() {
+  const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
+  terminal.sendText('mix test.watch');
+  if (config.focusOnTerminalAfterTest) terminal.show();
+}
+
+module.exports = {
+  name: 'extension.elixirWatchTestSuite',
+  handler,
+};

--- a/src/helpers/validations.js
+++ b/src/helpers/validations.js
@@ -1,0 +1,39 @@
+function isWindows(openedFilename) {
+  return openedFilename.includes('\\');
+}
+
+function isTestFile(openedFilename) {
+  return openedFilename.includes('_test.exs');
+}
+
+function isUmbrella(openedFilename) {
+  return isFolder(openedFilename, 'apps');
+}
+
+function isTestFolder(openedFilename) {
+  return isFolder(openedFilename, 'test');
+}
+
+function isFolder(openedFilename, folderName) {
+  if (!isWindows(openedFilename)) {
+    return openedFilename.includes(`/${folderName}/`);
+  } else {
+    return openedFilename.includes(`\\${folderName}\\`);
+  }
+}
+
+function getTestPathFilter(isUmbrella, isWindows) {
+  if (!isWindows) {
+    return isUmbrella ? /.*\/(apps\/.*)$/ : /.*\/(test\/.*)$/;
+  } else {
+    return isUmbrella ? /.*\\(apps\\.*)$/ : /.*\\(test\\.*)$/;
+  }
+}
+
+module.exports = {
+  isWindows,
+  isTestFile,
+  isUmbrella,
+  isTestFolder,
+  getTestPathFilter,
+};

--- a/src/helpers/validations.js
+++ b/src/helpers/validations.js
@@ -2,6 +2,13 @@ function isWindows(openedFilename) {
   return openedFilename.includes('\\');
 }
 
+const isFolder = (openedFilename, folderName) => {
+  if (!isWindows(openedFilename)) {
+    return openedFilename.includes(`/${folderName}/`);
+  }
+  return openedFilename.includes(`\\${folderName}\\`);
+};
+
 function isTestFile(openedFilename) {
   return openedFilename.includes('_test.exs');
 }
@@ -14,20 +21,12 @@ function isTestFolder(openedFilename) {
   return isFolder(openedFilename, 'test');
 }
 
-function isFolder(openedFilename, folderName) {
-  if (!isWindows(openedFilename)) {
-    return openedFilename.includes(`/${folderName}/`);
-  } else {
-    return openedFilename.includes(`\\${folderName}\\`);
-  }
-}
 
-function getTestPathFilter(isUmbrella, isWindows) {
-  if (!isWindows) {
-    return isUmbrella ? /.*\/(apps\/.*)$/ : /.*\/(test\/.*)$/;
-  } else {
-    return isUmbrella ? /.*\\(apps\\.*)$/ : /.*\\(test\\.*)$/;
+function getTestPathFilter(checkIsUmbrella, checkIsWindows) {
+  if (!checkIsWindows) {
+    return checkIsUmbrella ? /.*\/(apps\/.*)$/ : /.*\/(test\/.*)$/;
   }
+  return checkIsUmbrella ? /.*\\(apps\\.*)$/ : /.*\\(test\\.*)$/;
 }
 
 module.exports = {

--- a/src/helpers/validations.js
+++ b/src/helpers/validations.js
@@ -21,6 +21,12 @@ function isTestFolder(openedFilename) {
   return isFolder(openedFilename, 'test');
 }
 
+function isCodeFile(openedFilename) {
+  if (!isWindows(openedFilename)) {
+    return openedFilename.match(/(.*\/)(test|lib)(.*\/)(.*)(\.\w+)$/);
+  }
+  return openedFilename.match(/(.*\\)(test|lib)(.*\\)(.*)(\.\w+)$/);
+}
 
 function getTestPathFilter(checkIsUmbrella, checkIsWindows) {
   if (!checkIsWindows) {
@@ -34,5 +40,6 @@ module.exports = {
   isTestFile,
   isUmbrella,
   isTestFolder,
+  isCodeFile,
   getTestPathFilter,
 };


### PR DESCRIPTION
### :bug: Fix
- Fix command bugs for Windows users (path validation with `\\` instead of `/`)

### :page_facing_up: Changelog
- Add all test commands with [mix_test_watch](https://github.com/lpil/mix-test.watch) library
- Add validation helper to make it simple to maintain
- Update README with Watch tests section

Closes #58.