### PR TITLE
Stop conflicting run test shortcut with vs-code default keybinding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [1.6.0] = 2020-10-24
+- Fix command bugs for Windows users (path validation with `\\` instead of `/`)
+- Add all test commands with mix_test_watch library
+- Add validation helper to make it simple to maintain
+- Update README with Watch tests section
+- Change shortcut for running tests to CMD+SHIFT+I to avoid conflict with default keybinding
+
 ## [1.5.0] - 2020-10-16
 - Improve template on new test file
 - Improve test jump structure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [1.6.0] = 2020-10-24
+## [1.6.0] = 2020-10-30
 - Fix command bugs for Windows users (path validation with `\\` instead of `/`)
 - Add all test commands with mix_test_watch library
 - Add validation helper to make it simple to maintain

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The default keybinding is `Cmd + Shift + J` (macOS) and `Ctrl + Shift + J` (Linu
 
 ### Elixir Test: Run all tests on file
 
-The default keybinding is `Cmd + Shift  + I, F` (macOS) and `Ctrl + Shift  + I, F` (Linux/Windows)
+The default keybinding is `Cmd + Shift  + I, F` (macOS) and `Ctrl + Shift + 8, F` (Linux/Windows)
 
 ![Run all tests on file](https://media.giphy.com/media/lr81HlKkF60BoMnlvU/giphy.gif)
 
@@ -27,13 +27,13 @@ The default keybinding is `Cmd + Shift  + I, F` (macOS) and `Ctrl + Shift  + I, 
 
 This one does the same as above, but for a single test.
 
-The default keybinding is `Cmd + Shift  + I, C` (macOS) and `Ctrl + Shift  + I, C` (Linux/Windows)
+The default keybinding is `Cmd + Shift  + I, C` (macOS) and `Ctrl + Shift + 8, C` (Linux/Windows)
 
 ### Elixir Test: Run all tests in a folder
 
 This one does the same as above, but for all tests within a folder.
 
-The default keybinding is `Cmd + Shift  + I, D` (macOS) and `Ctrl + Shift  + I, D` (Linux/Windows)
+The default keybinding is `Cmd + Shift  + I, D` (macOS) and `Ctrl + Shift + 8, D` (Linux/Windows)
 
 Alternatively, right-click the folder in the Explorer and select `Elixir Test: Run all tests in a folder`.
 
@@ -41,7 +41,7 @@ Alternatively, right-click the folder in the Explorer and select `Elixir Test: R
 
 This one does the same as above, but for the entire test suite.
 
-The default keybinding is `Cmd + Shift  + I, S` (macOS) and `Ctrl + Shift  + I, S` (Linux/Windows)
+The default keybinding is `Cmd + Shift  + I, S` (macOS) and `Ctrl + Shift + 8, S` (Linux/Windows)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The default keybinding is `Cmd + Shift + J` (macOS) and `Ctrl + Shift + J` (Linu
 
 ### Elixir Test: Run all tests on file
 
-The default keybinding is `Cmd + Shift + K, F` (macOS) and `Ctrl + Shift + K, F` (Linux/Windows)
+The default keybinding is `Cmd + Shift  + I, F` (macOS) and `Ctrl + Shift  + I, F` (Linux/Windows)
 
 ![Run all tests on file](https://media.giphy.com/media/lr81HlKkF60BoMnlvU/giphy.gif)
 
@@ -27,13 +27,13 @@ The default keybinding is `Cmd + Shift + K, F` (macOS) and `Ctrl + Shift + K, F`
 
 This one does the same as above, but for a single test.
 
-The default keybinding is `Cmd + Shift + K, C` (macOS) and `Ctrl + Shift + K, C` (Linux/Windows)
+The default keybinding is `Cmd + Shift  + I, C` (macOS) and `Ctrl + Shift  + I, C` (Linux/Windows)
 
 ### Elixir Test: Run all tests in a folder
 
 This one does the same as above, but for all tests within a folder.
 
-The default keybinding is `Cmd + Shift + K, D` (macOS) and `Ctrl + Shift + K, D` (Linux/Windows)
+The default keybinding is `Cmd + Shift  + I, D` (macOS) and `Ctrl + Shift  + I, D` (Linux/Windows)
 
 Alternatively, right-click the folder in the Explorer and select `Elixir Test: Run all tests in a folder`.
 
@@ -41,7 +41,7 @@ Alternatively, right-click the folder in the Explorer and select `Elixir Test: R
 
 This one does the same as above, but for the entire test suite.
 
-The default keybinding is `Cmd + Shift + K, S` (macOS) and `Ctrl + Shift + K, S` (Linux/Windows)
+The default keybinding is `Cmd + Shift  + I, S` (macOS) and `Ctrl + Shift  + I, S` (Linux/Windows)
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -64,25 +64,25 @@
       },
       {
         "command": "extension.elixirRunTestAtCursor",
-        "key": "ctrl+shift+k c",
-        "mac": "cmd+shift+k c",
+        "key": "ctrl+shift+i c",
+        "mac": "cmd+shift+i c",
         "when": "editorTextFocus && editorLangId == 'elixir'"
       },
       {
         "command": "extension.elixirRunTestFile",
-        "key": "ctrl+shift+k f",
-        "mac": "cmd+shift+k f",
+        "key": "ctrl+shift+i f",
+        "mac": "cmd+shift+i f",
         "when": "editorTextFocus && editorLangId == 'elixir'"
       },
       {
         "command": "extension.elixirRunTestFolder",
-        "key": "ctrl+shift+k d",
-        "mac": "cmd+shift+k d"
+        "key": "ctrl+shift+i d",
+        "mac": "cmd+shift+i d"
       },
       {
         "command": "extension.elixirRunTestSuite",
-        "key": "ctrl+shift+k s",
-        "mac": "cmd+shift+k s",
+        "key": "ctrl+shift+i s",
+        "mac": "cmd+shift+i s",
         "when": "editorTextFocus && editorLangId == 'elixir'"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -64,24 +64,24 @@
       },
       {
         "command": "extension.elixirRunTestAtCursor",
-        "key": "ctrl+shift+i c",
+        "key": "ctrl+shift+8 c",
         "mac": "cmd+shift+i c",
         "when": "editorTextFocus && editorLangId == 'elixir'"
       },
       {
         "command": "extension.elixirRunTestFile",
-        "key": "ctrl+shift+i f",
+        "key": "ctrl+shift+8 f",
         "mac": "cmd+shift+i f",
         "when": "editorTextFocus && editorLangId == 'elixir'"
       },
       {
         "command": "extension.elixirRunTestFolder",
-        "key": "ctrl+shift+i d",
+        "key": "ctrl+shift+8 d",
         "mac": "cmd+shift+i d"
       },
       {
         "command": "extension.elixirRunTestSuite",
-        "key": "ctrl+shift+i s",
+        "key": "ctrl+shift+8 s",
         "mac": "cmd+shift+i s",
         "when": "editorTextFocus && editorLangId == 'elixir'"
       }


### PR DESCRIPTION
Fix #48 

I decided to go with `cmd+shift+i` because it's closer to the jump shortcut (`cmd+shift+j`) 😄

I personally don't use shortcuts, I just use `cmd+shift+p` and type what I need for almost everything, so if anyone has a better suggestion for this shortcut here, feel free to leave it here 🙂 

ps: I'm holding changelogs updates until I merge the other opened PR