### PR TITLE
Fix isCodeFile regexps

### DIFF
--- a/src/helpers/validations.js
+++ b/src/helpers/validations.js
@@ -23,9 +23,9 @@ function isTestFolder(openedFilename) {
 
 function isCodeFile(openedFilename) {
   if (!isWindows(openedFilename)) {
-    return openedFilename.match(/(.*\/)(test|lib)(.*\/)(.*)(\.\w+)$/);
+    return openedFilename.match(/(.*\/)(test|lib)(\/)(.*)(\.\w+)$/);
   }
-  return openedFilename.match(/(.*\\)(test|lib)(.*\\)(.*)(\.\w+)$/);
+  return openedFilename.match(/(.*\\)(test|lib)(\\)(.*)(\.\w+)$/);
 }
 
 function getTestPathFilter(checkIsUmbrella, checkIsWindows) {


### PR DESCRIPTION
Hey there! 🖖 

This PR updates `isCodeFile` regexps to only consider `/lib/` and `/test/` directories - and not `/lib*/` and `/test*/`. 

It is needed because the current regex causes problems with directories that have `lib|test` in its name. 

Closes #78