### PR TITLE
Ensure `watchTestAtCursor` is using `test.watch`

### DIFF
--- a/src/commands/watchTestAtCursor.js
+++ b/src/commands/watchTestAtCursor.js
@@ -2,7 +2,7 @@ const test = require('../helpers/test');
 const mix = require('../helpers/mix');
 
 function handler(context) {
-  test.onTestFile(context, (fileName, cursorLine) => mix.testFileAt(fileName, cursorLine));
+  test.onTestFile(context, (fileName, cursorLine) => mix.testWatchAt(fileName, cursorLine));
 }
 
 module.exports = {

--- a/src/helpers/mix.js
+++ b/src/helpers/mix.js
@@ -48,6 +48,10 @@ function testWatchPath(fileOrDirectory) {
   return mix({ command: 'test.watch', args: fileOrDirectory });
 }
 
+function testWatchAt(fileName, cursorPosition) {
+  return mix({ command: "test.watch", args: `${fileName}:${cursorPosition}` });
+}
+
 module.exports = {
   test,
   testCoverage,
@@ -57,4 +61,5 @@ module.exports = {
   testFileAt,
   testWatch,
   testWatchPath,
+  testWatchAt
 };


### PR DESCRIPTION
The `watchTestAtCursor` command was using the `mix.testFileAt` function which didn't really
watch for file changes at all, but rather just ran the function once. 

This change will fix that by actually calling `mix test.watch` so that `watchTestAtCursor` works
as intended 👍 